### PR TITLE
Update pages action to Node 24

### DIFF
--- a/.github/workflows/snake.yml
+++ b/.github/workflows/snake.yml
@@ -26,7 +26,7 @@ jobs:
             dist/github-snake.svg
             dist/github-snake-dark.svg?palette=github-dark
 
-      - uses: crazy-max/ghaction-github-pages@df5cc2bfa78282ded844b354faee141f06b41865
+      - uses: crazy-max/ghaction-github-pages@1d6ee9b181a81033a16bd707a1401afa978daab4
         with:
           target_branch: output
           build_dir: dist


### PR DESCRIPTION
Updates the GitHub Pages publish action to the Node 24 compatible release after the merged workflow surfaced a Node 20 deprecation annotation.\n\nVerification:\n- Confirmed pinned action manifest uses node24\n- Parsed workflow YAML\n- Ran pre-public sweep: no blockers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow tool to a new revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->