### PR TITLE
Refactor profile README into ZaneOS design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.impeccable.md
+design-options/

--- a/README.md
+++ b/README.md
@@ -1,104 +1,111 @@
 <p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:0D1117,50:7B61FF,100:00D9FF&height=200&section=header&text=Zane%20Wang&fontColor=ffffff&fontSize=70&fontAlignY=38&desc=Software%20%C2%B7%20AI%20%C2%B7%20Embedded%20%C2%B7%20GIS&descAlignY=60&descSize=18&animation=fadeIn" alt="Zane Wang" />
+  <img src="./assets/zaneos-hero.svg" alt="ZaneOS Arcade profile hero for Zane Wang" width="100%" />
+</p>
+
+<h1 align="center">Zane Wang</h1>
+
+<p align="center">
+  <strong>AI systems · agent memory · maps · hardware-aware software · developer tools · playful prototypes</strong>
 </p>
 
 <p align="center">
-  <a href="https://github.com/zelinewang">
-    <img src="https://readme-typing-svg.demolab.com?font=JetBrains+Mono&weight=600&size=22&duration=2800&pause=800&color=00D9FF&center=true&vCenter=true&width=620&lines=%3E+whoami;Software+%C2%B7+AI+%C2%B7+Embedded+%C2%B7+GIS+Engineer;Based+in+San+Francisco;Building+things+that+matter" alt="typing intro" />
-  </a>
+  I build useful systems for fuzzy problems: agents that remember, maps that explain,
+  tools that remove friction, and prototypes with enough personality to make the demo worth finishing.
+</p>
+
+<p align="center">
+  <a href="https://github.com/zelinewang">GitHub</a>
+  ·
+  <a href="https://www.linkedin.com/in/zane-wang7/">LinkedIn</a>
+  ·
+  <a href="https://x.com/zanewang102">X</a>
 </p>
 
 ---
 
-### `> cat about.txt`
+## ZaneOS Sidekick
 
-- 👋 Hi, I'm **Zane Wang**
-- 💡 Interested in **Software · AI · Embedded · GIS** — and the seams between them
-- 📍 Based in **San Francisco, CA**
-- 🤝 Always down to chat — connect with me on LinkedIn!
+`ZaneOS Sidekick` is the profile-native helper concept for this README: fast, public-signal-only, useful, and a little mischievous.
 
----
+| Mode | Prompt | Output |
+|---|---|---|
+| `ask` | “What is Zane weirdly good at?” | A short answer grounded in public projects and visible build signals. |
+| `match` | “Compare `@username` with Zane.” | Shared interests, complementary skills, and one fun collaboration angle. |
+| `quest` | “Turn this repo into a mission card.” | A project summary with proof, flavor, and a reason to click. |
+| `boop` | “Give me one useful strange idea.” | A tiny prototype pitch with enough personality to try. |
 
-### `> ls ~/skills`
-
-<p align="center">
-  <a href="https://skillicons.dev">
-    <img src="https://skillicons.dev/icons?i=py,cpp,c,ts,js,react,nodejs,docker,linux,bash,aws,gcp,tensorflow,pytorch,opencv,qgis,raspberrypi,arduino,git,vscode&theme=dark&perline=10" alt="tech stack" />
-  </a>
-</p>
-
----
-
-### `> git stats --all`
-
-<p align="center">
-  <a href="https://github.com/anuraghazra/github-readme-stats">
-    <img height="180" src="https://github-readme-stats.vercel.app/api?username=zelinewang&theme=tokyonight&show_icons=true&hide_border=true&include_all_commits=true&rank_icon=github" alt="GitHub stats" />
-  </a>
-  <a href="https://github.com/anuraghazra/github-readme-stats">
-    <img height="180" src="https://github-readme-stats.vercel.app/api/top-langs/?username=zelinewang&theme=tokyonight&hide_border=true&layout=compact&langs_count=8" alt="Top languages" />
-  </a>
-</p>
-
-<p align="center">
-  <img src="https://streak-stats.demolab.com?user=zelinewang&theme=tokyonight&hide_border=true" alt="Streak stats" />
-</p>
+```text
+zaneos ask "what should I talk to Zane about?"
+zaneos match @octocat
+zaneos quest dev-orchestrator
+zaneos boop "maps + agents + hardware"
+```
 
 ---
 
-### `> contrib --graph`
+## Capability Map
 
 <p align="center">
-  <img src="https://github-readme-activity-graph.vercel.app/graph?username=zelinewang&theme=tokyo-night&hide_border=true&line=00d9ff&point=7b61ff&area=true&area_color=7b61ff" alt="Activity graph" />
+  <img src="./assets/zaneos-capability-map.svg" alt="ZaneOS capability map: agents, maps, hardware-aware software, developer orchestration, and playful systems" width="100%" />
 </p>
+
+| Range | What it means |
+|---|---|
+| Agent memory | Persistent context, retrieval, tools, evaluation loops, and systems that keep moving when the problem gets messy. |
+| Maps + signals | GIS, satellite data, environmental context, and interfaces that make real-world complexity easier to reason about. |
+| Hardware-aware software | Code that respects sensors, devices, latency, failure modes, and the physical world outside the browser tab. |
+| Dev orchestration | CLIs, automation, review loops, and workflow glue that makes builders noticeably faster. |
+| Playful systems | Useful prototypes with story, motion, humor, and a small amount of suspicious charm. |
 
 ---
 
-### `> cat ~/trophies/*`
+## Build Quests
 
-<p align="center">
-  <a href="https://github.com/ryo-ma/github-profile-trophy">
-    <img src="https://github-profile-trophy.vercel.app/?username=zelinewang&theme=matrix&no-frame=true&column=7&margin-w=15&margin-h=15" alt="GitHub trophies" />
-  </a>
-</p>
+| Quest | Public signal | Why it matters |
+|---|---|---|
+| [`dev-orchestrator`](https://github.com/zelinewang/dev-orchestrator) | One-command AI development lifecycle | Turns “please help” into investigate → plan → execute → verify → ship. |
+| [`claudemem`](https://github.com/zelinewang/claudemem) | Persistent memory for agents | Keeps long-running engineering context searchable instead of evaporating. |
+| [`FireSight`](https://github.com/zelinewang/FireSight) | Wildfire intelligence with NASA satellite data | Connects AI, maps, and real-world signals. |
+| [`PulseConnect`](https://github.com/zelinewang/PulseConnect) | Computer-using AI outreach concept | Explores personalized workflows without turning the interface into a chore. |
+| [`santorini`](https://github.com/zelinewang/santorini) | Board-game logic | Small rules, big systems thinking, clean interactions. |
 
 ---
 
-### `> ./snake --eat-contributions`
+## Working Set
+
+`Python` · `Go` · `TypeScript` · `JavaScript` · `Java` · `C++` · `React` · `Node.js` · `Docker` · `Linux` · `QGIS` · `Raspberry Pi`
+
+I care less about logo walls and more about tool fit: quick prototypes when the idea is unstable, durable systems when the shape is clear, and automation whenever the same task appears twice.
+
+---
+
+## Live Signals
+
+<p align="center">
+  <img src="https://github-readme-activity-graph.vercel.app/graph?username=zelinewang&theme=github-light&hide_border=true&radius=16&area=true&custom_title=Zane%27s%20build%20signal" alt="Zane Wang's GitHub activity graph" width="100%" />
+</p>
 
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/zelinewang/zelinewang/output/github-snake-dark.svg" />
     <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/zelinewang/zelinewang/output/github-snake.svg" />
-    <img alt="snake eating my contributions" src="https://raw.githubusercontent.com/zelinewang/zelinewang/output/github-snake-dark.svg" />
+    <img alt="Contribution snake animation for Zane Wang" src="https://raw.githubusercontent.com/zelinewang/zelinewang/output/github-snake.svg" width="100%" />
   </picture>
+</p>
+
+<p align="center">
+  <sub>No fragile top-language card here: if a widget returns errors, it does not get to steer the design.</sub>
 </p>
 
 ---
 
-### `> connect --me`
+## Good Conversation Starters
+
+- Ask about agent memory, context, and how to make AI tools feel less forgetful.
+- Bring a messy workflow; I will probably try to automate the boring part.
+- Send a map, sensor stream, or strange dataset; I like systems with real-world texture.
+- Pitch a tiny tool with personality. Useful and funny is the best combination.
 
 <p align="center">
-  <a href="https://www.linkedin.com/in/zane-wang7/"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn" /></a>
-  <a href="https://github.com/zelinewang"><img src="https://img.shields.io/github/followers/zelinewang?style=for-the-badge&logo=github&color=7B61FF&labelColor=0D1117&label=Follow" alt="GitHub follow" /></a>
+  <strong>Current mode:</strong> shipping practical AI systems, polishing weird edges, and keeping the signal high.
 </p>
-
-<p align="center">
-  <img src="https://komarev.com/ghpvc/?username=zelinewang&style=for-the-badge&color=7B61FF&label=PROFILE+VIEWS" alt="Profile views" />
-</p>
-
-<p align="center"><i>"Build things that matter."</i></p>
-
-<p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:00D9FF,50:7B61FF,100:0D1117&height=120&section=footer" alt="footer wave" />
-</p>
-
-<!---
-zelinewang/zelinewang is a ✨ special ✨ repository because its README.md (this file) appears
-on your GitHub profile — the repo name must match your username exactly.
-
-Future option: deploy github-readme-stats to your own Vercel and point the stats card URLs
-at it; that's the only way the stats card itself can count private commits (the green
-contribution graph already counts private if you toggle Settings → Profile → "Include
-private contributions on my profile").
---->

--- a/assets/zaneos-capability-map.svg
+++ b/assets/zaneos-capability-map.svg
@@ -1,0 +1,60 @@
+<svg width="1200" height="360" viewBox="0 0 1200 360" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">ZaneOS capability map</title>
+  <desc id="desc">A capability map showing Zane Wang's public builder range across agents, maps, hardware-aware software, developer orchestration, and playful systems.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="360" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFF9ED"/>
+      <stop offset="1" stop-color="#EEF3E8"/>
+    </linearGradient>
+    <style>
+      .serif{font-family:ui-serif,Georgia,'Times New Roman',serif}
+      .sans{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}
+      .mono{font-family:'SFMono-Regular',Consolas,'Liberation Mono',monospace}
+      .ink{fill:#18211F}
+      .muted{fill:#66716B}
+      .small{font-size:13px;font-weight:700}
+    </style>
+  </defs>
+  <rect width="1200" height="360" rx="28" fill="url(#bg)"/>
+  <path d="M92 92 C214 64 346 124 470 92 C640 48 755 104 865 82 C980 60 1060 74 1120 118" stroke="#1B7C76" stroke-width="4" stroke-linecap="round" opacity=".34"/>
+  <path d="M120 252 C236 198 374 286 520 232 C694 168 774 262 936 208 C1028 178 1082 192 1120 220" stroke="#B45B38" stroke-width="4" stroke-linecap="round" opacity=".28"/>
+
+  <g transform="translate(70 62)">
+    <text x="0" y="0" class="mono small" fill="#B45B38" letter-spacing="1.4">OPERATING RANGE</text>
+    <text x="0" y="54" class="serif ink" font-size="50" font-weight="650" letter-spacing="-3">Useful systems with texture.</text>
+    <text x="2" y="92" class="sans muted" font-size="18">The signal is not one language or badge. It is how the pieces connect.</text>
+  </g>
+
+  <g transform="translate(70 190)">
+    <rect width="226" height="96" rx="22" fill="#18211F"/>
+    <text x="22" y="38" class="mono small" fill="#D6A73D">AGENT MEMORY</text>
+    <text x="22" y="65" class="sans" fill="#FFF9ED" font-size="16">context, recall, tools</text>
+  </g>
+  <g transform="translate(318 156)">
+    <rect width="250" height="116" rx="24" fill="#FFF9ED" stroke="#D8D0C2"/>
+    <text x="22" y="42" class="mono small ink">MAPS + SIGNALS</text>
+    <text x="22" y="70" class="sans muted" font-size="16">GIS, satellite data,</text>
+    <text x="22" y="94" class="sans muted" font-size="16">real-world constraints</text>
+  </g>
+  <g transform="translate(592 196)">
+    <rect width="220" height="92" rx="22" fill="#F4E6DD" stroke="#D8D0C2"/>
+    <text x="22" y="36" class="mono small ink">HARDWARE AWARE</text>
+    <text x="22" y="64" class="sans muted" font-size="16">sensors, devices, edges</text>
+  </g>
+  <g transform="translate(836 128)">
+    <rect width="278" height="128" rx="26" fill="#EEF3E8" stroke="#D8D0C2"/>
+    <text x="24" y="42" class="mono small ink">DEV ORCHESTRATION</text>
+    <text x="24" y="72" class="sans muted" font-size="16">automation, reviews,</text>
+    <text x="24" y="96" class="sans muted" font-size="16">sharp defaults, velocity</text>
+  </g>
+
+  <g transform="translate(520 52)">
+    <rect width="212" height="70" rx="20" fill="#EFE7C9" stroke="#D8D0C2"/>
+    <text x="22" y="31" class="mono small ink">PLAYFUL SYSTEMS</text>
+    <text x="22" y="53" class="sans muted" font-size="14">useful, funny, memorable</text>
+  </g>
+
+  <circle cx="302" cy="238" r="9" fill="#D6A73D"/>
+  <circle cx="580" cy="210" r="9" fill="#1B7C76"/>
+  <circle cx="825" cy="214" r="9" fill="#B45B38"/>
+</svg>

--- a/assets/zaneos-hero.svg
+++ b/assets/zaneos-hero.svg
@@ -1,0 +1,96 @@
+<svg width="1200" height="560" viewBox="0 0 1200 560" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">ZaneOS Arcade profile hero</title>
+  <desc id="desc">A polished ZaneOS command center with AI helper modes, project quests, and a small build snake motif for Zane Wang's GitHub profile.</desc>
+  <defs>
+    <linearGradient id="paper" x1="0" y1="0" x2="1200" y2="560" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFF9ED"/>
+      <stop offset=".58" stop-color="#F4EEE2"/>
+      <stop offset="1" stop-color="#E8EFE8"/>
+    </linearGradient>
+    <linearGradient id="snake" x1="0" y1="0" x2="170" y2="0" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#1B7C76"/>
+      <stop offset=".54" stop-color="#D6A73D"/>
+      <stop offset="1" stop-color="#B45B38"/>
+    </linearGradient>
+    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="22" stdDeviation="28" flood-color="#18211F" flood-opacity=".13"/>
+    </filter>
+    <style>
+      .serif{font-family:ui-serif,Georgia,'Times New Roman',serif}
+      .sans{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif}
+      .mono{font-family:'SFMono-Regular',Consolas,'Liberation Mono',monospace}
+      .ink{fill:#18211F}
+      .muted{fill:#66716B}
+      .label{font-size:13px;font-weight:800;letter-spacing:.12em}
+      .body{font-size:19px;line-height:1.45}
+      .small{font-size:13px;font-weight:650}
+    </style>
+  </defs>
+
+  <rect width="1200" height="560" rx="34" fill="url(#paper)"/>
+  <path d="M0 423 C182 375 310 468 520 408 C725 350 850 352 1014 407 C1096 435 1154 420 1200 383 V560 H0 V423Z" fill="#E4ECE0"/>
+  <path d="M70 70 H1130" stroke="#18211F" stroke-width="2" stroke-linecap="round" opacity=".14"/>
+  <circle cx="79" cy="43" r="7" fill="#B45B38"/>
+  <circle cx="104" cy="43" r="7" fill="#D6A73D"/>
+  <circle cx="129" cy="43" r="7" fill="#1B7C76"/>
+  <text x="156" y="48" class="mono label muted">ZELINEWANG / README.MD · PROFILE OPERATING SYSTEM</text>
+
+  <g transform="translate(70 98)">
+    <text x="0" y="0" class="mono label" fill="#B45B38">PERSONAL OS WITH PLAYABLE EDGES</text>
+    <text x="0" y="78" class="serif ink" font-size="74" font-weight="650" letter-spacing="-5">ZaneOS, now</text>
+    <text x="0" y="151" class="serif ink" font-size="74" font-weight="650" letter-spacing="-5">with side quests.</text>
+    <text x="2" y="198" class="sans body muted">AI systems, agent memory, maps, hardware instincts, and</text>
+    <text x="2" y="226" class="sans body muted">developer tools — organized like a calm command center,</text>
+    <text x="2" y="254" class="sans body muted">with enough arcade energy to stay memorable.</text>
+
+    <g transform="translate(0 292)" filter="url(#softShadow)">
+      <rect width="474" height="146" rx="24" fill="#18211F"/>
+      <text x="26" y="39" class="mono" fill="#D6A73D" font-size="17">&gt; zaneos ask "what is Zane weirdly good at?"</text>
+      <text x="26" y="75" class="mono" fill="#FFF9ED" font-size="17">fast answer: practical AI + maps + tooling taste</text>
+      <text x="26" y="111" class="mono" fill="#9ED8C7" font-size="17">side quest: compare a GitHub username</text>
+    </g>
+  </g>
+
+  <g transform="translate(620 94)" filter="url(#softShadow)">
+    <rect width="506" height="356" rx="30" fill="#FFF9ED" stroke="#D8D0C2"/>
+    <text x="28" y="43" class="mono label" fill="#1B7C76">ZANEOS SIDEKICK</text>
+    <text x="28" y="87" class="serif ink" font-size="39" font-weight="650" letter-spacing="-2">Ask, match, quest, boop.</text>
+    <text x="30" y="119" class="sans muted" font-size="16">A profile-native helper concept built from public signals only.</text>
+
+    <g transform="translate(28 148)">
+      <rect width="213" height="70" rx="18" fill="#F0E8D8" stroke="#D8D0C2"/>
+      <text x="18" y="29" class="mono small ink">ASK</text>
+      <text x="18" y="51" class="sans muted" font-size="13">short, grounded answers</text>
+      <rect x="231" width="213" height="70" rx="18" fill="#EEF3E8" stroke="#D8D0C2"/>
+      <text x="249" y="29" class="mono small ink">MATCH</text>
+      <text x="249" y="51" class="sans muted" font-size="13">username overlap finder</text>
+      <rect y="88" width="213" height="70" rx="18" fill="#F4E6DD" stroke="#D8D0C2"/>
+      <text x="18" y="117" class="mono small ink">QUEST</text>
+      <text x="18" y="139" class="sans muted" font-size="13">repo as mission card</text>
+      <rect x="231" y="88" width="213" height="70" rx="18" fill="#EFE7C9" stroke="#D8D0C2"/>
+      <text x="249" y="117" class="mono small ink">BOOP</text>
+      <text x="249" y="139" class="sans muted" font-size="13">one useful strange idea</text>
+    </g>
+
+    <g transform="translate(30 259)">
+      <text x="0" y="0" class="mono small muted">BUILD SNAKE SIGNAL</text>
+      <rect x="0" y="18" width="300" height="42" rx="13" fill="#18211F" opacity=".9"/>
+      <path d="M22 39 H72 C92 39 91 27 111 27 H168 C196 27 189 50 221 50 H264" stroke="url(#snake)" stroke-width="10" stroke-linecap="round"/>
+      <circle cx="267" cy="50" r="12" fill="#B45B38"/>
+      <circle cx="272" cy="46" r="2" fill="#FFF9ED"/>
+      <rect x="324" y="18" width="120" height="42" rx="21" fill="#18211F"/>
+      <text x="349" y="44" class="mono small" fill="#FFF9ED">score +1</text>
+    </g>
+  </g>
+
+  <g transform="translate(620 476)">
+    <rect width="118" height="30" rx="15" fill="#FFF9ED" stroke="#D8D0C2"/>
+    <text x="18" y="20" class="sans small ink">fast answers</text>
+    <rect x="132" width="138" height="30" rx="15" fill="#FFF9ED" stroke="#D8D0C2"/>
+    <text x="150" y="20" class="sans small ink">public signals</text>
+    <rect x="284" width="126" height="30" rx="15" fill="#FFF9ED" stroke="#D8D0C2"/>
+    <text x="302" y="20" class="sans small ink">low clutter</text>
+    <rect x="424" width="122" height="30" rx="15" fill="#FFF9ED" stroke="#D8D0C2"/>
+    <text x="442" y="20" class="sans small ink">high taste</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Refactor the profile README into a GitHub-safe ZaneOS Arcade design
- Add local SVG assets for a front-end-like hero and capability map
- Remove fragile stats/top-language widgets and keep stable activity graph + contribution snake
- Keep employer/company details out of the visible profile content

## Verification
- Parsed both SVG assets as valid XML
- Rendered README through GitHub Markdown API successfully
- Verified activity graph and snake URLs return HTTP 200
- Ran pre-public sweep: no Layer 1-4 blockers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Redesigned README with new sections: ZaneOS Sidekick modes reference, Capability Map overview, Build Quests, Working Set with technology stack, Live Signals activity visualization, and conversation starters.

* **Chores**
  * Updated .gitignore patterns for additional exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->