### PR TITLE
Tighten CodeQL (add JS-TS) + add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+# Dependabot config — version + security updates for the small surface
+# this profile repo actually has.
+#
+# Three ecosystems are tracked:
+#  1. github-actions  — pin/upgrade actions/checkout, github/codeql-action,
+#                       actions/setup-node, etc. Drift here can introduce
+#                       supply-chain risk if a newer action version is
+#                       compromised, OR keep us on an EOL version.
+#  2. npm             — sidekick.mjs uses the `openai` SDK at runtime
+#                       (DeepSeek's OpenAI-compatible endpoint). A
+#                       package.json + lockfile would activate this; if
+#                       neither exists, this section is a no-op.
+#  3. bundler / pip / etc. — not used in this repo.
+#
+# Cadence: weekly. Per-PR-limit kept low (2) so unattended updates don't
+# pile up. Security updates are unlimited via the separate
+# `enable-beta-ecosystems`-style auto-flag (set at the repo Security
+# settings level, not in this file).
+
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore(actions)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "chore(npm)"
+    labels:
+      - "dependencies"
+      - "npm"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,8 @@ jobs:
         include:
         - language: actions
           build-mode: none
+        - language: javascript-typescript
+          build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both


### PR DESCRIPTION
CodeQL was scanning workflow YAML only; now also scans .mjs runtime code. Add Dependabot for github-actions + npm.