### PR TITLE
Harden ZaneOS sidekick security boundaries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code owner review is required by the repository ruleset.
+# Keep the AI prompt, security docs, and automation surface under explicit review.
+
+* @zelinewang
+
+/AGENTS.md @zelinewang
+/ZANE_PERSONA.md @zelinewang
+/SECURITY.md @zelinewang
+/.github/ @zelinewang

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,9 @@
 # Dependabot config — version + security updates for the small surface
 # this profile repo actually has.
 #
-# Three ecosystems are tracked:
-#  1. github-actions  — pin/upgrade actions/checkout, github/codeql-action,
-#                       actions/setup-node, etc. Drift here can introduce
-#                       supply-chain risk if a newer action version is
-#                       compromised, OR keep us on an EOL version.
-#  2. npm             — sidekick.mjs uses the `openai` SDK at runtime
-#                       (DeepSeek's OpenAI-compatible endpoint). A
-#                       package.json + lockfile would activate this; if
-#                       neither exists, this section is a no-op.
-#  3. bundler / pip / etc. — not used in this repo.
+# Only GitHub Actions are tracked. Sidekick uses Node 22's built-in fetch
+# instead of a runtime npm dependency, so there is no package lock to keep
+# fresh and no install step in the secret-bearing workflow.
 #
 # Cadence: weekly. Per-PR-limit kept low (2) so unattended updates don't
 # pile up. Security updates are unlimited via the separate
@@ -33,17 +26,3 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
-
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "America/Los_Angeles"
-    open-pull-requests-limit: 2
-    commit-message:
-      prefix: "chore(npm)"
-    labels:
-      - "dependencies"
-      - "npm"

--- a/.github/scripts/sidekick.mjs
+++ b/.github/scripts/sidekick.mjs
@@ -3,7 +3,7 @@
 // ZaneOS Sidekick — replies to GitHub issues using a hosted LLM.
 //
 // Invoked from .github/workflows/zaneos-sidekick.yml when an issue is opened
-// whose title starts with "ZaneOS ".
+// whose title starts with one of the public ZaneOS mode prefixes.
 //
 // System prompt = ZANE_PERSONA.md (voice + content) ++ AGENTS.md (hard
 // boundaries: privacy, anti-impersonation, prompt-injection resistance).
@@ -26,11 +26,18 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
-// SDK is lazy-imported inside generateReply so DEBUG mode and unit tests can run
-// without the openai package installed.
-
 const MODEL = "deepseek-v4-flash"; // verified via https://api.deepseek.com/v1/models on 2026-05-01
 const BASE_URL = "https://api.deepseek.com";
+const CHAT_COMPLETIONS_URL = `${BASE_URL}/chat/completions`;
+const MAX_REPLY_CHARS = 2400;
+const CLOSING_LINE =
+  "_ZaneOS Sidekick — small, sharp, opinionated. Zane's AI, fed Zane's persona file. The model is the model; opinions are mine._";
+const FILTERED_REPLY = [
+  "I keep this endpoint to Zane's public work, and this generated reply tripped the safety filter.",
+  "Try a narrower ZaneOS prompt without private-data requests, off-platform contact requests, or unfamiliar links.",
+  "",
+  CLOSING_LINE,
+].join("\n");
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..", "..");
@@ -49,6 +56,10 @@ export function detectMode(title) {
     if (re.test(title)) return name;
   }
   return "ask"; // fallback: treat unknown ZaneOS-prefixed titles as ask
+}
+
+export function shouldHandleSidekickTitle(title) {
+  return MODE_PATTERNS.some(({ re }) => re.test(title));
 }
 
 // ── Prompt construction ───────────────────────────────────────────────────────
@@ -124,11 +135,7 @@ export async function generateReply(payload) {
     throw new Error("DEEPSEEK_API_KEY not set. Configure as a repo secret.");
   }
 
-  // DeepSeek API is OpenAI-compatible; use the openai SDK with a custom baseURL.
-  const { default: OpenAI } = await import("openai");
-  const client = new OpenAI({ apiKey, baseURL: BASE_URL });
-
-  const response = await client.chat.completions.create({
+  const response = await callChatCompletions(apiKey, {
     model: MODEL,
     max_tokens: 1024,
     messages: [
@@ -143,7 +150,86 @@ export async function generateReply(payload) {
     throw new Error("Model returned empty content");
   }
 
-  return { mode, reply: text };
+  return { mode, reply: sanitizeReply(text) };
+}
+
+async function callChatCompletions(apiKey, payload) {
+  const res = await fetch(CHAT_COMPLETIONS_URL, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const raw = await res.text();
+  let data;
+  try {
+    data = raw ? JSON.parse(raw) : {};
+  } catch {
+    throw new Error(`DeepSeek API returned non-JSON response (HTTP ${res.status})`);
+  }
+
+  if (!res.ok) {
+    const message = data?.error?.message || data?.message || `HTTP ${res.status}`;
+    throw new Error(`DeepSeek API request failed: ${message}`);
+  }
+
+  return data;
+}
+
+export function sanitizeReply(reply) {
+  const normalized = String(reply || "").trim();
+  if (!normalized) return FILTERED_REPLY;
+
+  if (violatesOutputPolicy(normalized)) {
+    return FILTERED_REPLY;
+  }
+
+  const withoutUnsafeLinks = stripUntrustedLinks(normalized);
+  const bounded = withoutUnsafeLinks.length > MAX_REPLY_CHARS
+    ? `${withoutUnsafeLinks.slice(0, MAX_REPLY_CHARS).trimEnd()}\n\n[trimmed for length]`
+    : withoutUnsafeLinks;
+
+  return bounded.includes(CLOSING_LINE)
+    ? bounded
+    : `${bounded}\n\n${CLOSING_LINE}`;
+}
+
+function violatesOutputPolicy(text) {
+  return [
+    /<\/?[a-z][^>]*>/i,
+    /!\[[^\]]*]\([^)]*\)/,
+    /\b(?:Zane|I)\s+(?:authorize|authorizes|approve|approves|promise|promises|commit|commits)\b/i,
+    /\b(?:email|dm|direct message|call|text)\s+(?:Zane|me|him)\b/i,
+    /@(?:everyone|here)\b/i,
+  ].some((re) => re.test(text));
+}
+
+function stripUntrustedLinks(text) {
+  return text
+    .replace(/\[([^\]]+)]\((https?:\/\/[^)\s]+)\)/g, (match, label, url) =>
+      isAllowedUrl(url) ? match : label,
+    )
+    .replace(/https?:\/\/[^\s)]+/g, (url) =>
+      isAllowedUrl(url) ? url : "[link omitted]",
+    );
+}
+
+function isAllowedUrl(url) {
+  try {
+    const { hostname } = new URL(url);
+    return [
+      "github.com",
+      "raw.githubusercontent.com",
+      "linkedin.com",
+      "www.linkedin.com",
+      "x.com",
+    ].some((allowed) => hostname === allowed || hostname.endsWith(`.${allowed}`));
+  } catch {
+    return false;
+  }
 }
 
 // ── CLI entrypoint (workflow calls this) ──────────────────────────────────────

--- a/.github/scripts/sidekick.test.mjs
+++ b/.github/scripts/sidekick.test.mjs
@@ -89,8 +89,10 @@ test("sanitizeReply: strips untrusted links but keeps GitHub links", () => {
   const reply = sanitizeReply(
     "Read [project](https://github.com/zelinewang/claudemem) and [promo](https://evil.example/x).",
   );
-  assert.ok(reply.includes("https://github.com/zelinewang/claudemem"));
-  assert.ok(!reply.includes("evil.example"));
+  const urls = [...reply.matchAll(/https?:\/\/[^\s)]+/g)].map(([url]) => new URL(url));
+  assert.equal(urls.length, 1);
+  assert.equal(urls[0].hostname, "github.com");
+  assert.equal(urls[0].pathname, "/zelinewang/claudemem");
 });
 
 test("sanitizeReply: filters raw HTML and authorization claims", () => {

--- a/.github/scripts/sidekick.test.mjs
+++ b/.github/scripts/sidekick.test.mjs
@@ -1,13 +1,13 @@
 // .github/scripts/sidekick.test.mjs
 //
-// Lightweight unit tests for the sidekick — runs without an Anthropic API key.
+// Lightweight unit tests for the sidekick — runs without a model API key.
 // Verifies mode detection and prompt construction are correct before the workflow
 // pays for a real model call.
 //
 // Run: node .github/scripts/sidekick.test.mjs
 
 import assert from "node:assert/strict";
-import { detectMode, buildPrompt } from "./sidekick.mjs";
+import { detectMode, shouldHandleSidekickTitle, buildPrompt, sanitizeReply } from "./sidekick.mjs";
 
 const tests = [];
 const test = (name, fn) => tests.push({ name, fn });
@@ -36,6 +36,12 @@ test("detectMode: unknown ZaneOS prefix → falls back to ask", () => {
 
 test("detectMode: case-insensitive", () => {
   assert.equal(detectMode("ZANEOS ASK: shouting"), "ask");
+});
+
+test("shouldHandleSidekickTitle: only accepts public sidequest modes", () => {
+  assert.equal(shouldHandleSidekickTitle("ZaneOS ask: what is your stack?"), true);
+  assert.equal(shouldHandleSidekickTitle("ZaneOS security: exploit details"), false);
+  assert.equal(shouldHandleSidekickTitle("ZaneOS hello world"), false);
 });
 
 // ── Prompt construction ───────────────────────────────────────────────────────
@@ -69,6 +75,29 @@ test("buildPrompt: user message includes the issue title and asker handle", asyn
   });
   assert.ok(userMessage.includes("ZaneOS match: @testuser"));
   assert.ok(userMessage.includes("@testuser"));
+});
+
+// ── Output policy ────────────────────────────────────────────────────────────
+
+test("sanitizeReply: appends the required closing line", () => {
+  const reply = sanitizeReply("Zane built small agent tools.");
+  assert.ok(reply.includes("Zane built small agent tools."));
+  assert.ok(reply.includes("ZaneOS Sidekick"));
+});
+
+test("sanitizeReply: strips untrusted links but keeps GitHub links", () => {
+  const reply = sanitizeReply(
+    "Read [project](https://github.com/zelinewang/claudemem) and [promo](https://evil.example/x).",
+  );
+  assert.ok(reply.includes("https://github.com/zelinewang/claudemem"));
+  assert.ok(!reply.includes("evil.example"));
+});
+
+test("sanitizeReply: filters raw HTML and authorization claims", () => {
+  const html = sanitizeReply("<img src=x onerror=alert(1)>");
+  const auth = sanitizeReply("Zane authorizes this intro.");
+  assert.ok(html.includes("tripped the safety filter"));
+  assert.ok(auth.includes("tripped the safety filter"));
 });
 
 // ── Run ───────────────────────────────────────────────────────────────────────

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -96,6 +96,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/refresh-stats.yml
+++ b/.github/workflows/refresh-stats.yml
@@ -22,13 +22,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           fetch-depth: 0  # need history to switch branches below
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
 

--- a/.github/workflows/zaneos-sidekick.yml
+++ b/.github/workflows/zaneos-sidekick.yml
@@ -10,8 +10,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: sidekick-${{ github.event.issue.number }}
-  cancel-in-progress: true
+  # Global serialization makes the issue-search quota gate best-effort but
+  # not bursty: a pile of simultaneous issues cannot all pass before labels
+  # and counts become visible.
+  group: zaneos-sidekick
+  cancel-in-progress: false
 
 env:
   PER_USER_DAILY_LIMIT: 3       # max ZaneOS issues per author per 24h
@@ -20,12 +23,20 @@ env:
 
 jobs:
   reply:
-    if: startsWith(github.event.issue.title, 'ZaneOS ')
+    if: |
+      startsWith(github.event.issue.title, 'ZaneOS ask:') ||
+      startsWith(github.event.issue.title, 'ZaneOS ask ') ||
+      startsWith(github.event.issue.title, 'ZaneOS match:') ||
+      startsWith(github.event.issue.title, 'ZaneOS match ') ||
+      startsWith(github.event.issue.title, 'ZaneOS boop:') ||
+      startsWith(github.event.issue.title, 'ZaneOS boop ') ||
+      startsWith(github.event.issue.title, 'ZaneOS quest:') ||
+      startsWith(github.event.issue.title, 'ZaneOS quest ')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           sparse-checkout: |
             ZANE_PERSONA.md
@@ -88,7 +99,7 @@ jobs:
 
       - name: Post rate-limit refusal (if limited)
         if: steps.rate-limit.outputs.limit_reason != ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           REASON: ${{ steps.rate-limit.outputs.limit_reason }}
           USER_COUNT: ${{ steps.rate-limit.outputs.user_count }}
@@ -129,13 +140,9 @@ jobs:
 
       - name: Setup Node
         if: steps.rate-limit.outputs.limit_reason == ''
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
-
-      - name: Install OpenAI SDK
-        if: steps.rate-limit.outputs.limit_reason == ''
-        run: npm install --no-save --no-fund openai@^4.79.0
 
       # SECURITY: all user-controlled inputs (issue title/body/author) flow via env vars
       # so they are passed as data to the shell, never interpolated into command strings.
@@ -178,7 +185,7 @@ jobs:
 
       - name: Comment, label, and close
         if: steps.rate-limit.outputs.limit_reason == ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           REPLY_BODY: ${{ steps.generate.outputs.reply }}
           MODE: ${{ steps.generate.outputs.mode }}
@@ -210,7 +217,7 @@ jobs:
 
       - name: On failure, post a graceful error
         if: failure() && steps.rate-limit.outputs.limit_reason == ''
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             await github.rest.issues.createComment({

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,10 @@ the bot is and isn't designed to defend against, so curious readers
 and serious adversaries both know where the surface is small and
 where it's accepted-risk.
 
-If you find a real vulnerability not described here, please open an
-issue with title `ZaneOS security:` and a brief description. Do **not**
-include exploit details in the title.
+If you find a real vulnerability not described here, use GitHub's
+private vulnerability reporting flow for this repository. If that is
+unavailable, open an issue with title `Security:` and a brief
+description. Do **not** include exploit details in the title or body.
 
 ## Trust boundary
 
@@ -133,7 +134,8 @@ The architecture above assumes:
 
 ## Reporting a vulnerability
 
-Open an issue with title `ZaneOS security:` followed by a one-line
-summary of the surface (e.g. `ZaneOS security: trigger discovery`).
-Do not include exploit details in the public issue body. Zane will
-move the conversation to a private channel and follow up.
+Use the repository's private vulnerability reporting flow. If you
+must use a public issue, use title `Security:` followed by a one-line
+summary of the surface (e.g. `Security: trigger discovery`). Do not
+include exploit details in the public title or body. Zane will move
+the conversation to a private channel and follow up.


### PR DESCRIPTION
## Summary\n- Restrict ZaneOS Sidekick workflow to the four public modes so security reports no longer enter the model path\n- Remove runtime npm/OpenAI SDK install and call DeepSeek via Node 22 fetch\n- Add deterministic output filtering, CODEOWNERS, SHA-pinned GitHub-owned actions, and updated security reporting docs\n- Keep Dependabot focused on GitHub Actions after removing the npm runtime dependency\n\n## Verification\n- node .github/scripts/sidekick.test.mjs (13 passed)\n- node --check .github/scripts/sidekick.mjs && node --check .github/scripts/sidekick.test.mjs && node --check .github/scripts/render-profile.mjs\n- go run github.com/rhysd/actionlint/cmd/actionlint@latest\n- git diff --check\n- gh api repos/zelinewang/zelinewang/actions/permissions/workflow => default_workflow_permissions=read\n- gh api repos/zelinewang/zelinewang/private-vulnerability-reporting => enabled\n- gh api repos/zelinewang/zelinewang/dependabot/alerts?state=open => 0\n- curl https://api.deepseek.com/chat/completions without key returned 401\n\n## Notes\n- Repo-level Actions default workflow permissions were changed from write to read outside this PR.\n- Private vulnerability reporting was already enabled.\n- pre-public sweep found no Layer 1-4 blockers, but existing history still contains old personal email authors and repo still lacks LICENSE/CHANGELOG/CONTRIBUTING warnings.