### PR TITLE
Harden ZaneOS contact detail filtering

### DIFF
--- a/.github/scripts/sidekick.mjs
+++ b/.github/scripts/sidekick.mjs
@@ -201,6 +201,9 @@ function violatesOutputPolicy(text) {
   return [
     /<\/?[a-z][^>]*>/i,
     /!\[[^\]]*]\([^)]*\)/,
+    /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i,
+    /(?:^|[^\d])(?:\+?1[\s.-]?)?(?:\([2-9]\d{2}\)|[2-9]\d{2})[\s.-]?[2-9]\d{2}[\s.-]?\d{4}\b/,
+    /\b\d{1,6}\s+[A-Za-z0-9][A-Za-z0-9 .'-]{2,}\s+(?:Avenue|Ave|Boulevard|Blvd|Court|Ct|Drive|Dr|Lane|Ln|Parkway|Pkwy|Place|Pl|Road|Rd|Street|St|Suite|Ste)\b/i,
     /\b(?:Zane|I)\s+(?:authorize|authorizes|approve|approves|promise|promises|commit|commits)\b/i,
     /\b(?:email|dm|direct message|call|text)\s+(?:Zane|me|him)\b/i,
     /@(?:everyone|here)\b/i,

--- a/.github/scripts/sidekick.test.mjs
+++ b/.github/scripts/sidekick.test.mjs
@@ -102,6 +102,15 @@ test("sanitizeReply: filters raw HTML and authorization claims", () => {
   assert.ok(auth.includes("tripped the safety filter"));
 });
 
+test("sanitizeReply: filters contact-shaped private details", () => {
+  const email = sanitizeReply("Zane's email is zane@example.com.");
+  const phone = sanitizeReply("Zane's phone is (415) 555-1212.");
+  const address = sanitizeReply("Zane works from 123 Main Street.");
+  assert.ok(email.includes("tripped the safety filter"));
+  assert.ok(phone.includes("tripped the safety filter"));
+  assert.ok(address.includes("tripped the safety filter"));
+});
+
 // ── Run ───────────────────────────────────────────────────────────────────────
 
 let passed = 0;


### PR DESCRIPTION
## Summary
- fail closed on contact-shaped email, phone, and street-address output from ZaneOS replies
- add regression coverage for private contact detail filtering

## Verification
- node .github/scripts/sidekick.test.mjs
- node --check .github/scripts/sidekick.mjs
- node --check .github/scripts/sidekick.test.mjs
- git diff --check
- go run github.com/rhysd/actionlint/cmd/actionlint@latest
- ~/.claude/scripts/pre-public-sweep.sh /Users/zane/zelinewang-profile-hardening-20260504 (0 blockers; existing governance warnings only)